### PR TITLE
Turn these policies into a new Contributing Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
-# README
-The list of policies for contributing for the SC4 project
+# :book: Scratch Client 4 Contributing Guide
 
-Hello!  Micah (-Archon-) here.  These are just some common-sense rules that need to be followed if you're planning to work on Scratch Client 4.  
+Hello! Thanks for wanting to contribute to SC4! This guide is here to explain :
 
-- **Commit messages**- make sure commit messages are descriptive so the entire team knows what was changed.
-- **Pull requests**- don't just make commits if you're not @micahlt, @hexsphere, or @ekmand.  Please open a pull request so that we can review the code first.  
-- **Language**- Yeah, yeah, I know this isn't Scratch, but let's not use foul language.  Be civil.  :D
-- **Issues**- Please only file issues that are relevant to the repository you're filing them in.  
+- What SC4 _is_ and _isn't_ about
+- Best practices and general rules
+- How to keep the discussion organized
+
+## :x: What Scratch Client 4 is and isn't
+
+Often, the nature of Scratch Client 4 projects are misunderstood.
+
+:x: Scratch Client 4 is **not** an alternative community, website, and/or project sharing platform for Scratch.  
+:x: Scratch Client 4 is **not** about improving, or reinventing the Scratch editor (what you make projects with).  
+:white_check_mark: Scratch Client 4 is about making apps that allow accessing **the existing Scratch _Community_**, managed by the MIT.
+
+## :art: Best practices and general rules
+
+- **Development environement** : You shouldn't edit things directly on GitHub. In order to make changes, please set up a local developement environement.
+This varies per project, but most of the time, you'll need to install [git](https://git-scm.com) and [Node.js](https://nodejs.org). If you aren't comfortable with using the command line, we recommend you use [GitHub Desktop](https://desktop.github.com). You _may_ do edits directly on GitHub for really minor changes, that don't need testing, like a typo.
+- **Commit messages** : Please make commit messages that accurately represent the work done. If you've made multiple changes, sum them up in the first line, and lisdt them in the extended description. Also, this isn't obligated, but always appreciated, that you use [Gitmojis](https://gitmoji.carloscuesta.me) in your commit messages.
+- **master branch** : The `master` branch in repositories should be the latest working development code. We are progressively adding protection for the branch on repositories, but whether it works and is enabled or not, please don't do things on it unless you're an admin, please make a new branch and make a pull request when you're ready to submit changes.
+- **Language** : Please stay polite and civil. This is a community-driven project, and everyone should feel welcome and comfortable.
 
 I think that's it!  Hexsphere, Ekmand, if you guys have anything to add, add it! 

--- a/README.md
+++ b/README.md
@@ -22,4 +22,21 @@ This varies per project, but most of the time, you'll need to install [git](http
 - **master branch** : The `master` branch in repositories should be the latest working development code. We are progressively adding protection for the branch on repositories, but whether it works and is enabled or not, please don't do things on it unless you're an admin, please make a new branch and make a pull request when you're ready to submit changes.
 - **Language** : Please stay polite and civil. This is a community-driven project, and everyone should feel welcome and comfortable.
 
-I think that's it!  Hexsphere, Ekmand, if you guys have anything to add, add it! 
+## :speech_balloon: Keeping the discussion organized
+
+You have an idea, question, report, request, or just wanna chat. Where should you write it?
+
+- **Feature/improvement requests and bug reports** for a specific project should go to the appropriate repository's Issues tab.
+- **General questions and long-term feature ideas** should go to the appropriate team's discussions.
+- **General organisational discussion**  should go into the Everyone team's discussions.
+- **General and off-topic chatting** should go to the Gitter chat, or to the appropriate Microsoft Teams channel.
+
+
+**If you need attention on your issue or PR**, please `cc` the appropriate teams/persons in your message or use the "Request review" feature.
+
+**Please stay on-topic in discussion threads**.
+
+We hope you'll help keep the project fun and useful, and make it even better!
+
+Thanks  
+the Scratch Client 4 team.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # :book: Scratch Client 4 Contributing Guide
 
-Hello! Thanks for wanting to contribute to SC4! This guide is here to explain :
+:wave: Hey! Thanks for willing to contribute to SC4! This guide is here to explain :
 
 - What SC4 _is_ and _isn't_ about
 - Best practices and general rules
 - How to keep the discussion organized
+
+Please carefully read it.
 
 ## :x: What Scratch Client 4 is and isn't
 
@@ -17,17 +19,17 @@ Often, the nature of Scratch Client 4 projects are misunderstood.
 ## :art: Best practices and general rules
 
 - **Development environement** : You shouldn't edit things directly on GitHub. In order to make changes, please set up a local developement environement.
-This varies per project, but most of the time, you'll need to install [git](https://git-scm.com) and [Node.js](https://nodejs.org). If you aren't comfortable with using the command line, we recommend you use [GitHub Desktop](https://desktop.github.com). You _may_ do edits directly on GitHub for really minor changes, that don't need testing, like a typo.
+This varies per project, but most of the time, you'll need to install [git](https://git-scm.com) and [Node.js](https://nodejs.org). Project-specific instructions can be found in their README files. If you aren't comfortable with using the command line, we recommend you use [GitHub Desktop](https://desktop.github.com). You _may_ do edits directly on GitHub for really minor changes, that don't need testing, like a typo.
 - **Commit messages** : Please make commit messages that accurately represent the work done. If you've made multiple changes, sum them up in the first line, and lisdt them in the extended description. Also, this isn't obligated, but always appreciated, that you use [Gitmojis](https://gitmoji.carloscuesta.me) in your commit messages.
 - **master branch** : The `master` branch in repositories should be the latest working development code. We are progressively adding protection for the branch on repositories, but whether it works and is enabled or not, please don't do things on it unless you're an admin, please make a new branch and make a pull request when you're ready to submit changes.
-- **Language** : Please stay polite and civil. This is a community-driven project, and everyone should feel welcome and comfortable.
+- **Language** : Please stay polite and civil. This is a community-driven project, and everyone should feel welcome and comfortable being part of that community.
 
 ## :speech_balloon: Keeping the discussion organized
 
 You have an idea, question, report, request, or just wanna chat. Where should you write it?
 
 - **Feature/improvement requests and bug reports** for a specific project should go to the appropriate repository's Issues tab.
-- **General questions and long-term feature ideas** should go to the appropriate team's discussions.
+- **General questions and long-term ideas** should go to the appropriate team's discussions.
 - **General organisational discussion**  should go into the Everyone team's discussions.
 - **General and off-topic chatting** should go to the Gitter chat, or to the appropriate Microsoft Teams channel.
 
@@ -36,7 +38,7 @@ You have an idea, question, report, request, or just wanna chat. Where should yo
 
 **Please stay on-topic in discussion threads**.
 
-We hope you'll help keep the project fun and useful, and make it even better!
+***We hope you'll help keep the project fun and useful, and make it even better!***
 
-Thanks  
-the Scratch Client 4 team.
+Thanks,  
+The Scratch Client 4 team.

--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ Often, the nature of Scratch Client 4 projects are misunderstood.
 ## :art: Best practices and general rules
 
 - **Development environement** : You shouldn't edit things directly on GitHub. In order to make changes, please set up a local developement environement.
-This varies per project, but most of the time, you'll need to install [git](https://git-scm.com) and [Node.js](https://nodejs.org). Project-specific instructions can be found in their README files. If you aren't comfortable with using the command line, we recommend you use [GitHub Desktop](https://desktop.github.com). You _may_ do edits directly on GitHub for really minor changes, that don't need testing, like a typo.
-- **Commit messages** : Please make commit messages that accurately represent the work done. If you've made multiple changes, sum them up in the first line, and lisdt them in the extended description. Also, this isn't obligated, but always appreciated, that you use [Gitmojis](https://gitmoji.carloscuesta.me) in your commit messages.
-- **master branch** : The `master` branch in repositories should be the latest working development code. We are progressively adding protection for the branch on repositories, but whether it works and is enabled or not, please don't do things on it unless you're an admin, please make a new branch and make a pull request when you're ready to submit changes.
+This varies per project, but most of the time, you'll need to install [git](https://git-scm.com) and [Node.js](https://nodejs.org). Project-specific instructions can be found in their README files.  
+If you aren't comfortable with using the command line, we recommend you use [GitHub Desktop](https://desktop.github.com). You _may_ do edits directly on GitHub for really minor changes, that don't need testing, like fixing a typo.
+- **Commit messages** : Please make commit messages that accurately represent the work done. If you've made multiple changes, sum them up in the first line, and list them in the extended description.  
+Also, it isn't obligated, but always appreciated, that you use [Gitmojis](https://gitmoji.carloscuesta.me) in your commit messages.
+- **master branch** : The `master` branch in repositories should be the latest working development code. We are progressively adding protection for the branch on repositories, but whether it's enabled and works or not, please don't do things on it unless you're an admin, please make a new branch, make your changes there, and make a pull request when you're ready to submit changes.
 - **Language** : Please stay polite and civil. This is a community-driven project, and everyone should feel welcome and comfortable being part of that community.
 
 ## :speech_balloon: Keeping the discussion organized
 
-You have an idea, question, report, request, or just wanna chat. Where should you write it?
+You have an idea, question, bug report, request, or just wanna chat. Where should you write it?
 
 - **Feature/improvement requests and bug reports** for a specific project should go to the appropriate repository's Issues tab.
 - **General questions and long-term ideas** should go to the appropriate team's discussions.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ You have an idea, question, report, request, or just wanna chat. Where should yo
 
 **Please stay on-topic in discussion threads**.
 
+## :notebook: Learning ressources
+
+Some things might be a bit new, or completely unknown to you. Here are great ressources to learn or perfect useful skills for contributing :
+
+- [GitHub Learning Lab](https://lab.github.com) offers courses to learn the GitHub workflow and other skills from a GitHub repository
+- [Scrimba](https://scrimba.com) offers interactive screencasts, where you can pause and edit the code at any moment, on a lot of different subjects
+- Some framework and language documentations are well-made for learning, like [LESS's](https://lesscss.org).
+- [W3Schools](https://w3schools.com) have complete coding courses, although they are more traditional written tutorials.
+
 ***We hope you'll help keep the project fun and useful, and make it even better!***
 
 Thanks,  


### PR DESCRIPTION
This is an attempt to turn the policies into an insightful, welcoming and friendly Contributing Guide. Please tell me what do you think of it, what I missed, what should I add, improve or remove, or if I should fire and give up on the whole thing 😀 

To-do
- [x] Maybe add some guides about the Git and GitHub workflow

Backlog To-do
- [x] Rename the repository
- [ ] Make a uniform README template
- [ ] Apply it to repositories
	- [ ] Client
	- [ ] Mobile
	- [ ] Landing

cc @Scratch-Client-4/everyone 